### PR TITLE
Update widget.js

### DIFF
--- a/nl.fokkezb.drawer/controllers/widget.js
+++ b/nl.fokkezb.drawer/controllers/widget.js
@@ -113,7 +113,7 @@ exports.off = function(event, callback, context) {
 };
 
 exports.trigger = function(event, args) {
-	return $.instance.fireEvent(event, callback, context);
+	return $.instance.fireEvent(event, args);
 };
 
 exports.addEventListener = exports.on;


### PR DESCRIPTION
Looks like a copy & paste bug that prevents custom events from firing. Not sure what the "context" param in exports.on()/exports.off() are supposed to do, either.
