### PR TITLE
isRightDrawerOpen / isLeftDrawerOpen is a property

### DIFF
--- a/nl.fokkezb.drawer/controllers/widget.js
+++ b/nl.fokkezb.drawer/controllers/widget.js
@@ -202,15 +202,15 @@ if (mod === 'dk.napp.drawer') {
 	};
 
 	$.isAnyWindowOpen = function () {
-		return $.instance.isLeftDrawerOpen() || $.instance.isRightDrawerOpen();
+		return $.instance.getIsLeftDrawerOpen() || $.instance.getIsRightDrawerOpen();
 	};
 
 	$.isLeftWindowOpen = function () {
-		return $.instance.isLeftDrawerOpen();
+		return $.instance.getIsLeftDrawerOpen();
 	};
 
 	$.isRightWindowOpen = function () {
-		return $.instance.isRightDrawerOpen();
+		return $.instance.getIsRightDrawerOpen();
 	};
 
 	$.leftWindow = $.leftView;


### PR DESCRIPTION
Fixed runtime error : Property 'isLeftDrawerOpen' of object #<Drawer> is not a function