### PR TITLE
[Android] onHome fix when right drawer is open

### DIFF
--- a/nl.fokkezb.drawer/controllers/widget.js
+++ b/nl.fokkezb.drawer/controllers/widget.js
@@ -115,6 +115,9 @@ if(OS_ANDROID){
 		if (actionBar) {
 			actionBar.setDisplayHomeAsUp(true);
 			actionBar.setOnHomeIconItemSelected(function () {
+				if ($.instance.isRightDrawerVisible) {
+					return $.instance.toggleRightWindow();
+				}
 				$.instance.toggleLeftWindow();
 			});
 		}


### PR DESCRIPTION
If the right drawer is visible the onHomeIcon presents a back arrow so it should close the right drawer instead.